### PR TITLE
Fix for the file URI on FreeBSD.

### DIFF
--- a/src/bin/media.c
+++ b/src/bin/media.c
@@ -1260,7 +1260,7 @@ media_add(Evas_Object *parent, const char *src, const Config *config, int mode,
    if (!sd->url)
      {
         Efreet_Uri *uri;
-        const char *file_path = eina_stringshare_printf("file:%s", sd->src);
+        const char *file_path = eina_stringshare_printf("file://%s", sd->src);
         uri = efreet_uri_decode(file_path);
         eina_stringshare_del(file_path);
         if (!uri)


### PR DESCRIPTION
On FreeBSD terminology complains about media_add() can not decode
'folder' and '/usr/home/xyz/1.png'.

This could be fixed by changing the URI from "file:%s" to "file://%s"
