### PR TITLE
Some fixes in ty* commands

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ Nicholas Hughart <mekius@mekius.net>
 Rafael Antognolli <antognolli@gmail.com>
 Rui Seabra <rms@1407.org>
 Vincent Torri <vincent.torri@gmail.com>
+Thibaut Broggi <broggi_t@epitech.eu>

--- a/src/bin/about.c
+++ b/src/bin/about.c
@@ -116,7 +116,8 @@ about_toggle(Evas_Object *win, Evas_Object *bg, Evas_Object *term,
               "Nicholas Hughart<br>"
               "Rafael Antognolli<br>"
               "Rui Seabra<br>"
-              "Vincent Torri<br>",
+              "Vincent Torri<br>"
+              "Thibaut Broggi<br>",
               "All rights reserved.<br>"
               "<br>"
               "Redistribution and use in source and binary forms, with or "

--- a/src/bin/tyalpha.c
+++ b/src/bin/tyalpha.c
@@ -33,10 +33,7 @@ main(int argc, char **argv)
           snprintf(tbuf, sizeof(tbuf), "%c}ap%s", 0x1b, argv[i]);
         else
           snprintf(tbuf, sizeof(tbuf), "%c}at%s", 0x1b, argv[i]);
-        if (write(0, tbuf, strlen(tbuf)) < 1) perror("write");
-        tbuf[0] = 0;
-        if (write(0, tbuf, 1) < 1) perror("write");
+        if (write(0, tbuf, strlen(tbuf) + 1) != (signed)(strlen(tbuf) + 1)) perror("write");
      }
-   exit(0);
    return 0;
 }

--- a/src/bin/tybg.c
+++ b/src/bin/tybg.c
@@ -35,10 +35,7 @@ main(int argc, char **argv)
           snprintf(tbuf, sizeof(tbuf), "%c}bp%s", 0x1b, path);
         else
           snprintf(tbuf, sizeof(tbuf), "%c}bt%s", 0x1b, path);
-        if (write(0, tbuf, strlen(tbuf)) < 1) perror("write");
-        tbuf[0] = 0;
-        if (write(0, tbuf, 1) < 1) perror("write");
+        if (write(0, tbuf, strlen(tbuf) + 1) != (signed)(strlen(tbuf) + 1)) perror("write");
      }
-   exit(0);
    return 0;
 }

--- a/src/bin/tyls.c
+++ b/src/bin/tyls.c
@@ -101,6 +101,8 @@ size_print(char *buf, int bufsz, char *sz, unsigned long long size)
 #define WHITE   7
 #define BRIGHT  8
 
+#define COUNT_OF(arr) (sizeof(arr) / sizeof(*arr))
+
 // #3399ff
 // 51 153 355
 // as 6x6x6
@@ -790,13 +792,14 @@ main(int argc, char **argv)
           {
              char *path;
              char *cmp[] = {"-c", "-m", "-l"};
+             int modes[] = {SMALL, MEDIUM, LARGE};
              int j;
 
-             for (j = 0; j < 3; j++)
+             for (j = 0; j < COUNT_OF(cmp) ; j++)
                {
                  if (!strcmp(argv[i], cmp[j]))
                    {
-                     mode = j;
+                     mode = modes[j];
                      if (++i >= argc) break;
                    }
                }

--- a/src/bin/tyls.c
+++ b/src/bin/tyls.c
@@ -789,25 +789,18 @@ main(int argc, char **argv)
         for (i = 1; i < argc; i++)
           {
              char *path;
+             char *cmp[] = {"-c", "-m", "-l"};
+             int j;
 
-             if (!strcmp(argv[i], "-c"))
+             for (j = 0; j < 3; j++)
                {
-                  mode = SMALL;
-                  i++;
-                  if (i >= argc) break;
+                 if (!strcmp(argv[i], cmp[j]))
+                   {
+                     mode = j;
+                     if (++i >= argc) break;
+                   }
                }
-             else if (!strcmp(argv[i], "-m"))
-               {
-                  mode = MEDIUM;
-                  i++;
-                  if (i >= argc) break;
-               }
-             else if (!strcmp(argv[i], "-l"))
-               {
-                  mode = LARGE;
-                  i++;
-                  if (i >= argc) break;
-               }
+             if (i >= argc) break;
              path = argv[i];
              rp = ecore_file_realpath(path);
              if (rp)

--- a/src/bin/typop.c
+++ b/src/bin/typop.c
@@ -25,10 +25,7 @@ main(int argc, char **argv)
         path = argv[i];
         if (realpath(path, buf)) path = buf;
         snprintf(tbuf, sizeof(tbuf), "%c}pn%s", 0x1b, path);
-        if (write(0, tbuf, strlen(tbuf)) < 1) perror("write");
-        tbuf[0] = 0;
-        if (write(0, tbuf, 1) < 1) perror("write");
+        if (write(0, tbuf, strlen(tbuf) + 1) != (signed)(strlen(tbuf) + 1)) perror("write");
      }
-   exit(0);
    return 0;
 }

--- a/src/bin/tyq.c
+++ b/src/bin/tyq.c
@@ -25,10 +25,7 @@ main(int argc, char **argv)
         path = argv[i];
         if (realpath(path, buf)) path = buf;
         snprintf(tbuf, sizeof(tbuf), "%c}pq%s", 0x1b, path);
-        if (write(0, tbuf, strlen(tbuf)) < 1) perror("write");
-        tbuf[0] = 0;
-        if (write(0, tbuf, 1) < 1) perror("write");
+        if (write(0, tbuf, strlen(tbuf) + 1) != (signed)(strlen(tbuf) + 1)) perror("write");
      }
-   exit(0);
    return 0;
 }


### PR DESCRIPTION
### In commands **tybg**, **tyalpha**, **typop** and **tyq** :

*exit(0); return 0;* is useless since main is called like that:
```c
exit(main(argc, argv, envp));
```
So, I removed call to **exit()** in main.
There is also a possible bug here :
```c
if (write(0, tbuf, strlen(tbuf)) < 1) perror("write");
tbuf[0] = 0;
if (write(0, tbuf, 1) < 1) perror("write");
```
If first call to **write()** succeed, but the second fail, terminology will wait for a *\0* charactere, and it will not be easy to use. Second call is useless. So, I replace it by the following :
```c
if (write(0, tbuf, strlen(tbuf) + 1) != (signed)(strlen(tbuf) + 1)) perror("write");
```
The *\0* char is implicit at the end of the tbuf. I also verify if **all** the characters are correctly printed (not just if write() fail).

### In command **tyls** :
I just did some refacto in some part of the code. Nothing really improved.