### PR TITLE
Check if the font size really needs to be changed

### DIFF
--- a/src/bin/termio.c
+++ b/src/bin/termio.c
@@ -450,7 +450,7 @@ _font_size_set(Evas_Object *obj, int size)
 
    if (size < 5) size = 5;
    else if (size > 100) size = 100;
-   if (config)
+   if (config && config->font.size != size)
      {
         config->temporary = EINA_TRUE;
         config->font.size = size;


### PR DESCRIPTION
Changing the font size also causes the current selection to be lost, so it's
nice to avoid it when not needed.