### PR TITLE
License year changed.

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 Copyright notice for Terminology (BSD 2-Clause License):
 
-Copyright (C) 2005 Carsten Haitzler and various contributors (see AUTHORS)
+Copyright (C) 2012 Carsten Haitzler and various contributors (see AUTHORS)
 
 All rights reserved.
 

--- a/COPYING
+++ b/COPYING
@@ -1,6 +1,6 @@
 Copyright notice for Terminology (BSD 2-Clause License):
 
-Copyright (C) 2012-2018 Carsten Haitzler and various contributors (see AUTHORS)
+Copyright (C) 2005 Carsten Haitzler and various contributors (see AUTHORS)
 
 All rights reserved.
 


### PR DESCRIPTION
Convention states you should just put the year the work was first produced in, instead of doing a range.